### PR TITLE
Make sqlite and postgres more similar

### DIFF
--- a/database/database.go
+++ b/database/database.go
@@ -20,6 +20,7 @@ import (
 	"database/sql"
 
 	_ "github.com/lib/pq"
+	_ "github.com/mattn/go-sqlite3"
 
 	log "maunium.net/go/maulogger/v2"
 )

--- a/database/message.go
+++ b/database/message.go
@@ -18,6 +18,7 @@ package database
 
 import (
 	"bytes"
+	"strings"
 	"database/sql"
 	"encoding/json"
 
@@ -34,18 +35,33 @@ type MessageQuery struct {
 }
 
 func (mq *MessageQuery) CreateTable(dbType string) error {
-	_, err := mq.db.Exec(`CREATE TABLE IF NOT EXISTS message (
-		chat_jid      VARCHAR(255),
-		chat_receiver VARCHAR(255),
-		jid           VARCHAR(255),
-		mxid          VARCHAR(255) NOT NULL UNIQUE,
-		sender        VARCHAR(255)  NOT NULL,
-		content       bytea         NOT NULL,
+	if strings.ToLower(dbType) == "postgres" {
+		_, err := mq.db.Exec(`CREATE TABLE IF NOT EXISTS message (
+			chat_jid      VARCHAR(255),
+			chat_receiver VARCHAR(255),
+			jid           VARCHAR(255),
+			mxid          VARCHAR(255) NOT NULL UNIQUE,
+			sender        VARCHAR(255)  NOT NULL,
+			content       bytea         NOT NULL,
 
-		PRIMARY KEY (chat_jid, chat_receiver, jid),
-		FOREIGN KEY (chat_jid, chat_receiver) REFERENCES portal(jid, receiver)
-	)`)
+			PRIMARY KEY (chat_jid, chat_receiver, jid),
+			FOREIGN KEY (chat_jid, chat_receiver) REFERENCES portal(jid, receiver)
+		)`)
+		return err
+	} else {
+		_, err := mq.db.Exec(`CREATE TABLE IF NOT EXISTS message (
+			chat_jid      VARCHAR(255),
+			chat_receiver VARCHAR(255),
+			jid           VARCHAR(255),
+			mxid          VARCHAR(255) NOT NULL UNIQUE,
+			sender        VARCHAR(255)  NOT NULL,
+			content       BLOB          NOT NULL,
+
+			PRIMARY KEY (chat_jid, chat_receiver, jid),
+			FOREIGN KEY (chat_jid, chat_receiver) REFERENCES portal(jid, receiver)
+		)`)
 	return err
+	}
 }
 
 func (mq *MessageQuery) New() *Message {

--- a/database/user.go
+++ b/database/user.go
@@ -35,7 +35,7 @@ type UserQuery struct {
 
 func (uq *UserQuery) CreateTable(dbType string) error {
 	if strings.ToLower(dbType) == "postgres" {
-		_, err := uq.db.Exec(`CREATE TABLE IF NOT EXISTS whatsapp_user (
+		_, err := uq.db.Exec(`CREATE TABLE IF NOT EXISTS "user" (
 			mxid VARCHAR(255) PRIMARY KEY,
 			jid  VARCHAR(255)  UNIQUE,
 
@@ -49,7 +49,7 @@ func (uq *UserQuery) CreateTable(dbType string) error {
 		)`)
 		return err
 	} else {
-		_, err := uq.db.Exec(`CREATE TABLE IF NOT EXISTS whatsapp_user (
+		_, err := uq.db.Exec(`CREATE TABLE IF NOT EXISTS "user" (
 			mxid VARCHAR(255) PRIMARY KEY,
 			jid  VARCHAR(255)  UNIQUE,
 
@@ -61,7 +61,7 @@ func (uq *UserQuery) CreateTable(dbType string) error {
 			enc_key      BLOB,
 			mac_key      BLOB
 		)`)
-		return err		
+		return err
 	}
 }
 
@@ -73,7 +73,7 @@ func (uq *UserQuery) New() *User {
 }
 
 func (uq *UserQuery) GetAll() (users []*User) {
-	rows, err := uq.db.Query("SELECT * FROM whatsapp_user")
+	rows, err := uq.db.Query(`SELECT * FROM "user"`)
 	if err != nil || rows == nil {
 		return nil
 	}
@@ -85,7 +85,7 @@ func (uq *UserQuery) GetAll() (users []*User) {
 }
 
 func (uq *UserQuery) GetByMXID(userID types.MatrixUserID) *User {
-	row := uq.db.QueryRow("SELECT * FROM whatsapp_user WHERE mxid=$1", userID)
+	row := uq.db.QueryRow(`SELECT * FROM "user" WHERE mxid=$1`, userID)
 	if row == nil {
 		return nil
 	}
@@ -93,7 +93,7 @@ func (uq *UserQuery) GetByMXID(userID types.MatrixUserID) *User {
 }
 
 func (uq *UserQuery) GetByJID(userID types.WhatsAppID) *User {
-	row := uq.db.QueryRow("SELECT * FROM whatsapp_user WHERE jid=$1", stripSuffix(userID))
+	row := uq.db.QueryRow(`SELECT * FROM "user" WHERE jid=$1`, stripSuffix(userID))
 	if row == nil {
 		return nil
 	}
@@ -166,7 +166,7 @@ func (user *User) sessionUnptr() (sess whatsapp.Session) {
 
 func (user *User) Insert() {
 	sess := user.sessionUnptr()
-	_, err := user.db.Exec("INSERT INTO whatsapp_user VALUES ($1, $2, $3, $4, $5, $6, $7, $8)", user.MXID, user.jidPtr(),
+	_, err := user.db.Exec(`INSERT INTO "user" VALUES ($1, $2, $3, $4, $5, $6, $7, $8)`, user.MXID, user.jidPtr(),
 		user.ManagementRoom,
 		sess.ClientId, sess.ClientToken, sess.ServerToken, sess.EncKey, sess.MacKey)
 	if err != nil {
@@ -176,7 +176,7 @@ func (user *User) Insert() {
 
 func (user *User) Update() {
 	sess := user.sessionUnptr()
-	_, err := user.db.Exec("UPDATE whatsapp_user SET jid=$1, management_room=$2, client_id=$3, client_token=$4, server_token=$5, enc_key=$6, mac_key=$7 WHERE mxid=$8",
+	_, err := user.db.Exec(`UPDATE "user" SET jid=$1, management_room=$2, client_id=$3, client_token=$4, server_token=$5, enc_key=$6, mac_key=$7 WHERE mxid=$8`,
 		user.jidPtr(), user.ManagementRoom,
 		sess.ClientId, sess.ClientToken, sess.ServerToken, sess.EncKey, sess.MacKey,
 		user.MXID)


### PR DESCRIPTION
This adapts the code paths for sqlite and postgres, so this should work on both dbs and allows for migration.